### PR TITLE
MPI_Status test

### DIFF
--- a/status/.gitignore
+++ b/status/.gitignore
@@ -1,0 +1,15 @@
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache
+config.log
+config.status
+config
+configure
+
+.deps
+.libs
+
+*.o
+
+src/status_test

--- a/status/Makefile.am
+++ b/status/Makefile.am
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved
+#
+# $COPYRIGHT$
+#
+
+SUBDIRS = src

--- a/status/README.md
+++ b/status/README.md
@@ -1,0 +1,41 @@
+# Test MPI_Status conversion functions
+
+MPI-4:18.2.5 has a good diagram showing all the possible conversion
+functions for an MPI_Status.  We need to test each edge in that
+diagram.
+
+```
+                     MPI_Status
+                       / ^ \ ^
+  C types and         / /   \ \
+  functions          / /     \ \
+                 (1)/ /(2) (3)\ \(4)
+                   / /   (5)   \ \
+                  / / <-------- ' \
+ MPI_F08_status  ' --------------> \ MPI_Fint array
+                         (6)
+
+                         (7)
+ TYPE(MPI_Status)  <-------------- INTEGER array of size
+                   --------------> MPI_STATUS_SIZE (in Fortran)
+		         (8)
+
+```
+
+1. MPI_Status_c2f08()
+1. MPI_Status_f082c()
+1. MPI_Status_c2f()
+1. MPI_Status_f2c()
+1. MPI_Status_f2f08() (in C)
+1. MPI_Status_f082f() (in C)
+1. MPI_Status_f2f08() (in Fortran)
+   1. In the `mpi` module
+   1. In the `mpi_f08` module
+1. MPI_Status_f082f() (in Fortran)
+   1. In the `mpi` module
+   1. In the `mpi_f08` module
+
+By transitive property, if we test each leg in the above diagram, then
+we effectively certify the conversion journey of a status across any
+combination of the legs in the diagram (i.e., any possible correct
+status conversion).

--- a/status/autogen.sh
+++ b/status/autogen.sh
@@ -1,0 +1,2 @@
+:
+autoreconf -ivf

--- a/status/configure.ac
+++ b/status/configure.ac
@@ -1,0 +1,194 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2012-2020 Cisco Systems, Inc.  All rights reserved.
+#
+# $COPYRIGHT$
+#
+
+dnl
+dnl Init autoconf
+dnl
+
+AC_PREREQ([2.67])
+AC_INIT([mpi-status-test], [1.0], [http://www.open-mpi.org])
+AC_CONFIG_AUX_DIR([config])
+AC_CONFIG_MACRO_DIR([config])
+AC_CONFIG_SRCDIR([.])
+
+echo "Configuring MPI_Status test"
+
+AM_INIT_AUTOMAKE([1.11 foreign -Wall -Werror])
+
+# If Automake supports silent rules, enable them.
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
+AH_TOP([/* -*- c -*-
+ *
+ *	MPI_Status test suite configuation header file.
+ *      See the top-level LICENSE file for license and copyright
+ *      information.
+ */
+
+#ifndef MPI_STATUS_TEST_CONFIG_H
+#define MPI_STATUS_TEST_CONFIG_H
+])
+AH_BOTTOM([#endif /* MPI_STATUS_TEST_CONFIG_H */])
+
+dnl
+dnl Make automake clean emacs ~ files for "make clean"
+dnl
+
+CLEANFILES="*~"
+AC_SUBST(CLEANFILES)
+
+dnl
+dnl Get various programs
+dnl Bias towards mpicc/mpic++/mpif77
+dnl C compiler
+dnl
+
+if test "$CC" != ""; then
+    BASE="`basename $CC`"
+else
+    BASE=
+fi
+if test "$BASE" = "" -o "$BASE" = "." -o "$BASE" = "cc" -o \
+    "$BASE" = "gcc" -o "$BASE" = "xlc" -o "$BASE" = "pgcc" -o \
+    "$BASE" = "icc"; then
+    AC_CHECK_PROG(HAVE_MPICC, mpicc, yes, no)
+    if test "$HAVE_MPICC" = "yes"; then
+        CC=mpicc
+        export CC
+    fi
+fi
+
+CFLAGS_save=$CFLAGS
+AC_PROG_CC
+CFLAGS=$CFLAGS_save
+
+dnl
+dnl Fortran compiler
+dnl
+
+if test "$FC" != ""; then
+    BASE="`basename $FC`"
+else
+    BASE=
+fi
+if test "$BASE" = "" -o "$BASE" = "." -o "$BASE" = "f77" -o \
+    "$BASE" = "g77" -o "$BASE" = "f90" -o "$BASE" = "g90" -o \
+    "$BASE" = "xlf" -o "$BASE" = "ifc" -o "$BASE" = "pgf77"; then
+    AC_CHECK_PROG(HAVE_MPIFORT, mpifort, yes, no)
+    AS_IF([test "$HAVE_MPIFORT" = "yes"],
+          [FC=mpifort],
+          [AC_CHECK_PROG([HAVE_MPIF90], mpif90, yes, no)
+           AS_IF([test "$HAVE_MPIF90" = "yes"],
+                 [FC=mpif90],
+                 [AC_CHECK_PROG([HAVE_MPIF77], mpif77, yes, no)
+                  AS_IF([test "$HAVE_MPIF77" = "yes"],
+                        [FC=mpif77],
+                        [AC_MSG_WARN([Cannot find a suitable MPI compiler])
+                         AC_MSG_ERROR([Cannot continue])
+                        ])
+                 ])
+         ])
+    export FC
+fi
+
+FCFLAGS_save=$FCFLAGS
+AC_PROG_FC
+FCFLAGS=$FCFLAGS_save
+
+dnl
+dnl Because these are meant to be used for debugging, after all
+dnl
+
+if test -z "$CFLAGS"; then
+    CFLAGS="-g"
+fi
+if test -z "$FCFLAGS"; then
+    FCFLAGS="-g";
+fi
+AC_SUBST(FCFLAGS)
+if test -z "$FFLAGS"; then
+    FFLAGS="-g";
+fi
+AC_SUBST(FFLAGS)
+
+dnl
+dnl Ensure that we can compile and link a C MPI program
+dnl
+
+AC_LANG_PUSH([C])
+AC_CHECK_HEADERS(mpi.h)
+
+AC_MSG_CHECKING([if linking MPI program works])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mpi.h>
+]],
+                                [[MPI_Comm a = MPI_COMM_WORLD]])],
+               [AC_MSG_RESULT([yes])],
+               [AC_MSG_RESULT([no])
+                AC_MSG_WARN([Simple MPI program fails to link])
+                AC_MSG_ERROR([Cannot continue])
+               ])
+AC_LANG_POP([C])
+
+dnl
+dnl Make sure we have the C type MPI_F08_status
+dnl
+
+AC_CHECK_TYPES([MPI_F08_status], [],
+               [AC_MSG_WARN([Cannot find MPI_F08_status type])
+                AC_MSG_ERROR([Cannot continue])],
+               [#include <mpi.h>])
+
+dnl
+dnl Check for the different Fortran bindings
+dnl
+
+AC_LANG_PUSH([Fortran])
+
+AC_MSG_CHECKING([for mpif.h])
+AC_LINK_IFELSE([AC_LANG_PROGRAM(,
+                                [[        include 'mpif.h'
+        integer a
+        a = MPI_COMM_WORLD]])],
+               [AC_MSG_RESULT([yes])],
+               [AC_MSG_RESULT([no])
+                AC_MSG_WARN([Cannot compile an mpif.h program])
+                AC_MSG_ERROR([Cannot continue])
+               ])
+
+AC_MSG_CHECKING([for mpi module])
+AC_LINK_IFELSE([AC_LANG_PROGRAM(,
+                                [[        use mpi
+        integer a
+        a = MPI_COMM_WORLD]])],
+               [AC_MSG_RESULT([yes])],
+               [AC_MSG_RESULT([no])
+                AC_MSG_WARN([Cannot compile a 'use mpi' program])
+                AC_MSG_ERROR([Cannot continue])
+               ])
+
+AC_MSG_CHECKING([for mpi_f08 module])
+AC_LINK_IFELSE([AC_LANG_PROGRAM(,
+                                [[        use mpi_f08
+        Type(MPI_Comm) :: a
+        a = MPI_COMM_WORLD]])],
+               [AC_MSG_RESULT([yes])],
+               [AC_MSG_RESULT([no])
+                AC_MSG_WARN([Cannot compile a 'use mpi_f08' program])
+                AC_MSG_ERROR([Cannot continue])
+               ])
+
+AC_LANG_POP([Fortran])
+
+dnl
+dnl Party on
+dnl
+
+AC_CONFIG_FILES([
+    Makefile
+    src/Makefile
+])
+AC_OUTPUT

--- a/status/src/Makefile.am
+++ b/status/src/Makefile.am
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved
+#
+# $COPYRIGHT$
+#
+
+noinst_PROGRAMS = status_test
+
+status_test_SOURCES = \
+        status_fortran.F90 \
+        status_c.c

--- a/status/src/status_c.c
+++ b/status/src/status_c.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2020 Cisco Systems, Inc.
+ *
+ * $COPYRIGHT$
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <alloca.h>
+
+#include "mpi.h"
+
+
+// Globals in this file, for convenience.
+static int rank = -1;
+static MPI_Fint f_mpi_status_size = -1;
+static MPI_Fint f_mpi_source = -1;
+static MPI_Fint f_mpi_tag = -1;
+static MPI_Fint f_mpi_error = -1;
+
+
+// Prototype the Fortran functions that we'll call from here in C
+void check_cancelled_f_wrapper(MPI_Fint *f_status,
+                               MPI_Fint *expected_value,
+                               const char *msg);
+void check_count_f(MPI_Fint *f_status, MPI_Fint *expected_tag,
+                   const char *msg);
+void check_cancelled_f08_wrapper(MPI_F08_status *f08_status,
+                                 MPI_Fint *expected_value,
+                                 const char *msg);
+void check_count_f08(MPI_F08_status *f08_status, MPI_Fint *expected_tag,
+                     const char *msg);
+
+/////////////////////////////////////////////////////////////////////////
+
+// The first argument is either an MPI_Fint or something that can be
+// upcasted to an MPI_Fint (i.e., a C int, but sizeof(int)==4 and
+// sizeof(MPI_Fint)==8).
+static void check_int(MPI_Fint fint, int cint, const char *msg)
+{
+    if (fint != cint) {
+        printf("Error: %s: %d != %d\n", msg, fint, cint);
+        exit(1);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+static void check_cancelled_c(MPI_Status *status, int expected_value,
+                              const char *msg)
+{
+    int value;
+    MPI_Test_cancelled(status, &value);
+    if (value != expected_value) {
+        printf("Error: %s: %d != %d\n", msg, value, expected_value);
+        exit(1);
+    }
+}
+
+static void check_count_c(MPI_Status *status, MPI_Datatype type,
+                          int expected_count, const char *msg)
+{
+    int count;
+    MPI_Get_count(status, MPI_INTEGER, &count);
+    check_int(count, expected_count, msg);
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+static void test_f082c(MPI_F08_status *f08_status, MPI_Fint f08_tag,
+                MPI_Fint expected_count)
+{
+    MPI_Status c_status;
+
+    printf("Testing C MPI_Status_f082c\n");
+
+    // NOTE: The f08_status has "cancelled" set to true.
+    MPI_Status_f082c(f08_status, &c_status);
+
+    check_int(c_status.MPI_SOURCE, rank, "f082c source");
+    check_int(c_status.MPI_TAG, (int) f08_tag, "f082c tag");
+    check_int(c_status.MPI_ERROR, MPI_SUCCESS, "f082c success");
+    check_cancelled_c(&c_status, 1, "f082c cancelled=.true.");
+    check_count_c(&c_status, MPI_INTEGER, (int) expected_count,
+                  "f082c count");
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+static void test_c2f08(MPI_Status *c_status, int c_tag,
+                       int expected_count)
+{
+    MPI_Fint temp;
+    MPI_F08_status f08_status;
+
+    printf("Testing C MPI_Status_c2f08\n");
+
+    // First test with cancelled=0
+    MPI_Status_set_cancelled(c_status, 0);
+    MPI_Status_c2f08(c_status, &f08_status);
+
+    check_int(f08_status.MPI_SOURCE, rank, "c2f08 source");
+    check_int(f08_status.MPI_TAG, c_tag, "c2f08 tag");
+    check_int(f08_status.MPI_ERROR, MPI_SUCCESS, "c2f08 success");
+    temp = 0;
+    check_cancelled_f08_wrapper(&f08_status, &temp, "c2f08 cancelled=0");
+    temp = (MPI_Fint) expected_count;
+    check_count_f08(&f08_status, &temp, "c2f08 count");
+
+    // Then test with cancelled=1
+    MPI_Status_set_cancelled(c_status, 1);
+    MPI_Status_c2f08(c_status, &f08_status);
+
+    check_int(f08_status.MPI_SOURCE, rank, "c2f08 source");
+    check_int(f08_status.MPI_TAG, c_tag, "c2f08 tag");
+    check_int(f08_status.MPI_ERROR, MPI_SUCCESS, "c2f08 success");
+    temp = (MPI_Fint) 1;
+    check_cancelled_f08_wrapper(&f08_status, &temp, "c2f08 cancelled=1");
+    temp = (MPI_Fint) expected_count;
+    check_count_f08(&f08_status, &temp, "c2f08 count");
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+static void test_f2c(MPI_Fint *f_status, MPI_Fint f_tag,
+                     MPI_Fint expected_count)
+{
+    MPI_Status c_status;
+
+    printf("Testing C MPI_Status_f2c\n");
+
+    // NOTE: The f_status has "cancelled" set to true.
+    MPI_Status_f2c(f_status, &c_status);
+
+    check_int(c_status.MPI_SOURCE, rank, "f2c source");
+    check_int(c_status.MPI_TAG, (int) f_tag, "f2c tag");
+    check_int(c_status.MPI_ERROR, MPI_SUCCESS, "f2c success");
+    check_cancelled_c(&c_status, 1, "f2c cancelled=.true.");
+    check_count_c(&c_status, MPI_INTEGER, (int) expected_count,
+                  "f2c count");
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+static void test_c2f(MPI_Status *c_status, int c_tag,
+                     int expected_count)
+{
+    MPI_Fint temp;
+    MPI_Fint *f_status = alloca((size_t) f_mpi_status_size * sizeof(MPI_Fint));
+
+    printf("Testing C MPI_Status_c2f\n");
+
+    // First test with cancelled=0
+    MPI_Status_set_cancelled(c_status, 0);
+    MPI_Status_c2f(c_status, f_status);
+
+    check_int(f_status[f_mpi_source], rank, "c2f source");
+    check_int(f_status[f_mpi_tag], c_tag, "c2f tag");
+    check_int(f_status[f_mpi_error], MPI_SUCCESS, "c2f success");
+    temp = 0;
+    check_cancelled_f_wrapper(f_status, &temp, "c2f cancelled=0");
+    temp = (MPI_Fint) expected_count;
+    check_count_f(f_status, &temp, "c2f count");
+
+    // Then test with cancelled=1
+    MPI_Status_set_cancelled(c_status, 1);
+    MPI_Status_c2f(c_status, f_status);
+
+    check_int(f_status[f_mpi_source], rank, "c2f source 2");
+    check_int(f_status[f_mpi_tag], c_tag, "c2f tag 2");
+    check_int(f_status[f_mpi_error], MPI_SUCCESS, "c2f success 2");
+    temp = (MPI_Fint) 1;
+    check_cancelled_f_wrapper(f_status, &temp, "c2f cancelled=1");
+    temp = (MPI_Fint) expected_count;
+    check_count_f(f_status, &temp, "c2f count 2");
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+static void test_f082f(MPI_F08_status *f08_status, MPI_Fint f08_tag,
+                       MPI_Fint expected_count)
+{
+    MPI_Fint temp;
+    MPI_Fint *f_status = alloca((size_t) f_mpi_status_size * sizeof(MPI_Fint));
+
+    printf("Testing C MPI_Status_f082f\n");
+
+    // NOTE: The f08_status has "cancelled" set to true.
+    MPI_Status_f082f(f08_status, f_status);
+
+    check_int(f_status[f_mpi_source], rank, "f082f source");
+    check_int(f_status[f_mpi_tag], f08_tag, "f082f tag");
+    check_int(f_status[f_mpi_error], MPI_SUCCESS, "f082f success");
+    temp = 1;
+    check_cancelled_f_wrapper(f_status, &temp, "f082f cancelled=.true.");
+    check_count_f(f_status, &expected_count, "f082f count");
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+static void test_f2f08(MPI_Fint *f_status, MPI_Fint f_tag,
+                       MPI_Fint expected_count)
+{
+    MPI_Fint temp;
+    MPI_F08_status f08_status;
+
+    printf("Testing C MPI_Status_f2f08\n");
+
+    // NOTE: The f_status has "cancelled" set to true.
+    MPI_Status_f2f08(f_status, &f08_status);
+
+    check_int(f08_status.MPI_SOURCE, rank, "f2f08 source");
+    check_int(f08_status.MPI_TAG, f_tag, "f2f08 tag");
+    check_int(f08_status.MPI_ERROR, MPI_SUCCESS, "f2f08 success");
+    temp = 1;
+    check_cancelled_f_wrapper(f_status, &temp, "f2f08 cancelled=.true.");
+    check_count_f(f_status, &expected_count, "f2f08 count");
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+static void generate_c_status(MPI_Status *status, int c_tag, int c_count)
+{
+    MPI_Fint sendbuf, recvbuf;
+    MPI_Request requests[2];
+    MPI_Status statuses[2];
+
+    // Create a status the "normal" way
+    //
+    // Use a non-blocking send/receive to ourselves so that we can use
+    // an array WAIT function so that the MPI_ERROR element will be
+    // set in the resulting status.
+
+    sendbuf = 789;
+    MPI_Irecv(&recvbuf, 1, MPI_INTEGER, rank, c_tag, MPI_COMM_WORLD,
+              &requests[0]);
+    MPI_Isend(&sendbuf, 1, MPI_INTEGER, rank, c_tag, MPI_COMM_WORLD,
+              &requests[1]);
+    MPI_Waitall(2, requests, statuses);
+
+    // Copy the resulting receive status to our output status
+    memcpy(status, &statuses[0], sizeof(MPI_Status));
+
+    // Now set some slightly different values in the status that
+    // results in a very large count (larger than can be represented
+    // by 32 bits)
+    MPI_Status_set_cancelled(status, 0);
+    MPI_Status_set_elements(status, MPI_INTEGER, c_count);
+}
+
+/////////////////////////////////////////////////////////////////////////
+
+// This function is the entry point from Fortran
+void test_c_functions(MPI_F08_status *f08_status, MPI_Fint *f08_tag,
+                      MPI_Fint *f_status, MPI_Fint *f_tag, MPI_Fint *f_count,
+                      MPI_Fint *mpi_status_size, MPI_Fint *mpi_source,
+                      MPI_Fint *mpi_tag, MPI_Fint *mpi_error)
+{
+    MPI_Status c_status;
+    int c_tag;
+    int c_count;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    // MPI (up to MPI-4, at least) specifically defines that
+    // MPI_STATUS_SIZE is only available in Fortran.  So we need to
+    // pass it in from Fortran so that we can have it here in C.
+    // Ditto for MPI_SOURCE, MPI_TAG, and MPI_ERROR.  But note that
+    // those values are indexes in to an array, and since Fortran
+    // indexes on 1 and C indexes on 0, subtract 1 from those values
+    // here in C.
+    f_mpi_status_size = *mpi_status_size;
+    f_mpi_source      = *mpi_source - 1;
+    f_mpi_tag         = *mpi_tag - 1;
+    f_mpi_error       = *mpi_error - 1;
+
+    printf("Testing C functions...\n");
+
+    // Make the C values slightly different than the Fortran values
+    c_tag = 333;
+    c_count = ((int) *f_count) + 99;
+
+    generate_c_status(&c_status, c_tag, c_count);
+
+    test_f082c(f08_status, *f08_tag, *f_count);
+    test_c2f08(&c_status, c_tag, c_count);
+
+    test_f2c(f_status, *f_tag, *f_count);
+    test_c2f(&c_status, c_tag, c_count);
+
+    test_f082f(f08_status, *f08_tag, *f_count);
+    test_f2f08(f_status, *f_tag, *f_count);
+}

--- a/status/src/status_fortran.F90
+++ b/status/src/status_fortran.F90
@@ -1,0 +1,409 @@
+!
+! Copyright (C) 2020 Cisco Systems, Inc.
+!
+! $COPYRIGHT$
+!
+! See the README.md for more information
+
+program main
+  use mpi_f08
+  implicit none
+
+  ! Interface to the C routine we're going to call from here in
+  ! Fortran
+  interface
+     subroutine test_c_functions(f08_status, f08_tag, f_status, f_tag, count, &
+          f_mpi_status_size, f_mpi_source, f_mpi_tag, f_mpi_error) &
+          BIND(C, name="test_c_functions")
+       use mpi_f08
+       implicit none
+       type(MPI_Status), intent(in) :: f08_status
+       integer, intent(in) :: f08_tag
+       integer, dimension(MPI_STATUS_SIZE), intent(in) :: f_status
+       integer, intent(in) :: f_tag
+       integer, intent(in) :: count
+       integer, intent(in) :: f_mpi_status_size, f_mpi_source, f_mpi_tag, f_mpi_error
+     end subroutine test_c_functions
+  end interface
+
+  type(MPI_Status) :: f08_status
+  integer, dimension(MPI_STATUS_SIZE) :: f_status
+  integer :: f08_tag
+  integer :: f_tag
+  integer :: count
+  integer :: f_true, f_false
+
+  call MPI_Init()
+
+  f08_tag = 111
+  f_tag = 222
+  ! An array of this many integers is 2GB in length
+  count = 536870912
+  ! This puts the array of integers over 2GB in length
+  count = count + 10
+
+  call generate_f08_status(f08_status, f08_tag, count)
+  call generate_f_status(f_status, f_tag, count)
+
+  call test_fortran_functions(f08_status, f08_tag, f_status, f_tag, count)
+
+  ! NOTE: This calls a C function.
+  ! NOTE: We are calling the C functions with "cancelled" set to true
+  ! on both the f08 and f statuses!
+  call test_c_functions(f08_status, f08_tag, f_status, f_tag, count, &
+       MPI_STATUS_SIZE, MPI_SOURCE, MPI_TAG, MPI_ERROR)
+
+  call MPI_Finalize()
+
+end program main
+
+!==================================================================
+
+subroutine test_fortran_functions(f08_status, f08_tag, f_status, f_tag, count)
+  use mpi_f08
+  implicit none
+  type(MPI_Status), intent(inout) :: f08_status
+  integer, intent(in) :: f08_tag
+  integer, dimension(MPI_STATUS_SIZE), intent(inout) :: f_status
+  integer, intent(in) :: f_tag
+  integer, intent(in) :: count
+
+  print *, 'Testing Fortran functions...'
+
+  ! Test MPI_Status_f082f (in Fortran)
+  !
+  ! These subroutines are called in deliberate order: the _mpif08
+  ! subroutine *before* the _mpi subroutine.  This is because the
+  ! _mpif08 subroutine can called MPI_Set_cancelled() on the F08
+  ! status.  So we know for 100% sure the cancelled value of the
+  ! status is when leaving the _mpif08 function, and check for that
+  ! value in the _mpi subroutine.
+  call test_fortran_f082f_mpif08(f08_status, f08_tag, count)
+  call test_fortran_f082f_mpi(f08_status, f08_tag, count)
+
+  ! Test MPI_Status_f2f08 (in Fortran)
+  !
+  ! Analogous to above, call the _mpi subroutine first so that it can
+  ! call MPI_Set_cancelled() on the f_status, and therefore we can
+  ! know for 100% what the cancelled value of that status is when
+  ! calling the _mpif08 subroutine..
+  call test_fortran_f2f08_mpi(f_status, f_tag, count)
+  call test_fortran_f2f08_mpif08(f_status, f_tag, count)
+end subroutine test_fortran_functions
+
+!==================================================================
+
+subroutine generate_f08_status(status, tag, count)
+  use mpi_f08
+  implicit none
+  type(MPI_Status), intent(out) :: status
+  integer, intent(in) :: tag
+  integer, intent(in) :: count
+  integer :: rank
+  integer :: sendbuf, recvbuf
+  type(MPI_Request), dimension(2) :: requests
+  type(MPI_Status), dimension(2) :: statuses
+
+  ! Create a status the "normal" way
+  !
+  ! Use a non-blocking send/receive to ourselves so that we can use an
+  ! array WAIT function so that the MPI_ERROR element will be set in
+  ! the resulting status.
+
+  call MPI_Comm_rank(MPI_COMM_WORLD, rank)
+
+  sendbuf = 123
+  call MPI_Irecv(recvbuf, 1, MPI_INTEGER, rank, tag, MPI_COMM_WORLD, &
+       requests(1))
+  call MPI_Isend(sendbuf, 1, MPI_INTEGER, rank, tag, MPI_COMM_WORLD, &
+       requests(2))
+  call MPI_Waitall(2, requests, statuses)
+
+  ! Copy the resulting receive status to our output status
+  status = statuses(1)
+
+  ! Now set some slightly different values in the status that results
+  ! in a very large count (larger than can be represented by 32 bits)
+  call MPI_Status_set_cancelled(status, .false.)
+  call MPI_Status_set_elements(status, MPI_INTEGER, count)
+end subroutine generate_f08_status
+
+!==================================================================
+
+subroutine generate_f_status(status, tag, count)
+  use mpi
+  implicit none
+  integer, dimension(MPI_STATUS_SIZE), intent(out) :: status
+  integer, intent(in) :: tag
+  integer, intent(in) :: count
+  integer :: rank, ierr, sendbuf, recvbuf
+  integer, dimension(2) :: requests
+  integer, dimension(MPI_STATUS_SIZE, 2) :: statuses
+
+  ! Create a status the "normal" way
+  !
+  ! Use a non-blocking send/receive to ourselves so that we can use an
+  ! array WAIT function so that the MPI_ERROR element will be set in
+  ! the resulting status.
+
+  call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+
+  sendbuf = 456
+  call MPI_Irecv(recvbuf, 1, MPI_INTEGER, rank, tag, MPI_COMM_WORLD, &
+       requests(1), ierr)
+  call MPI_Isend(sendbuf, 1, MPI_INTEGER, rank, tag, MPI_COMM_WORLD, &
+       requests(2), ierr)
+  call MPI_Waitall(2, requests, statuses, ierr)
+
+  ! Copy the resulting receive status to our output status
+  status = statuses(:, 1)
+
+  ! Now set some slightly different values in the status that results
+  ! in a very large count (larger than can be represented by 32 bits)
+  call MPI_Status_set_cancelled(status, .false., ierr)
+  call MPI_Status_set_elements(status, MPI_INTEGER, count, ierr)
+end subroutine generate_f_status
+
+!==================================================================
+
+subroutine check_integer(a, b, msg)
+  implicit none
+  integer, intent(in) :: a, b
+  character(len=*), intent(in) :: msg
+
+  if (a .ne. b) then
+     print *, "Error: ", msg, ": ", a, "<>", b
+     stop
+  end if
+end subroutine check_integer
+
+!==================================================================
+
+! This subroutine is called from C.
+! We have to translate the 1/0 from C into a Fortran logical.  Sigh.
+subroutine check_cancelled_f_wrapper(f_status, expected_value, msg) &
+     BIND(C, name="check_cancelled_f_wrapper")
+  use mpi
+  implicit none
+  integer, dimension(MPI_STATUS_SIZE), intent(in) :: f_status
+  integer, intent(in) :: expected_value
+  character(len=1), intent(in) :: msg
+
+  if (expected_value .eq. 1) then
+     call check_cancelled_f(f_status, .true., msg)
+  else
+     call check_cancelled_f(f_status, .false., msg)
+  end if
+end subroutine check_cancelled_f_wrapper
+
+subroutine check_cancelled_f(f_status, expected_value, msg) &
+     BIND(C, name="check_cancelled_f")
+  use mpi
+  implicit none
+  integer, dimension(MPI_STATUS_SIZE), intent(in) :: f_status
+  logical, intent(in) :: expected_value
+  character(len=1), intent(in) :: msg
+  integer :: ierr
+  logical :: value
+
+  call MPI_Test_cancelled(f_status, value, ierr)
+  if (value .neqv. expected_value) then
+     print *, "Error: ", msg, ": ", value, "<>", expected_value
+     stop
+  end if
+end subroutine check_cancelled_f
+
+!------------------------------------------------------------------
+
+! This subroutine is called from both Fortran and C
+subroutine check_count_f(f_status, expected_count, msg) &
+     BIND(C, name="check_count_f")
+  use mpi
+  implicit none
+  integer, dimension(MPI_STATUS_SIZE), intent(in) :: f_status
+  integer, intent(in) :: expected_count
+  character(len=1), intent(in) :: msg
+  integer :: ierr
+  integer :: count
+
+  call MPI_Get_count(f_status, MPI_INTEGER, count, ierr)
+  call check_integer(count, expected_count, msg)
+end subroutine check_count_f
+
+!------------------------------------------------------------------
+
+subroutine test_fortran_f082f_mpi(f08_status, expected_tag, expected_count)
+  use mpi
+  implicit none
+  type(MPI_Status), intent(inout) :: f08_status
+  integer, intent(in) :: expected_tag
+  integer, intent(in) :: expected_count
+
+  integer, dimension(MPI_STATUS_SIZE) :: f_status
+  integer :: rank, ierr
+
+  print *, 'Testing Fortran MPI_Status_f082f (mpi module)'
+
+  call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+
+  ! Coming in to this routine, the f08 status will be set to .true.
+  call MPI_Status_f082f(f08_status, f_status, ierr)
+
+  call check_integer(f_status(MPI_SOURCE), rank, "f082f source 2")
+  call check_integer(f_status(MPI_TAG), expected_tag, "f082f tag 2")
+  call check_integer(f_status(MPI_ERROR), MPI_SUCCESS, "f08f2 error 2")
+  call check_cancelled_f(f_status, .true., "f082f .true.")
+  call check_count_f(f_status, expected_count, "f082f count")
+end subroutine test_fortran_f082f_mpi
+
+!------------------------------------------------------------------
+
+subroutine test_fortran_f082f_mpif08(f08_status, expected_tag, expected_count)
+  use mpi_f08
+  implicit none
+  type(MPI_Status), intent(inout) :: f08_status
+  integer, intent(in) :: expected_tag
+  integer, intent(in) :: expected_count
+
+  integer, dimension(MPI_STATUS_SIZE) :: f_status
+  integer :: rank
+
+  print *, 'Testing Fortran MPI_Status_f082f (mpi_f08 module)'
+
+  call MPI_Comm_rank(MPI_COMM_WORLD, rank)
+
+  ! Set the canceled status to .false. and check everything
+  call MPI_Status_set_cancelled(f08_status, .false.)
+  call MPI_Status_f082f(f08_status, f_status)
+
+  call check_integer(f_status(MPI_SOURCE), rank, "f082f source")
+  call check_integer(f_status(MPI_TAG), expected_tag, "f082f tag")
+  call check_integer(f_status(MPI_ERROR), MPI_SUCCESS, "f082f error")
+  call check_cancelled_f(f_status, .false., "f082f .false.")
+  call check_count_f(f_status, expected_count, "f082f count")
+
+  ! Set the canceled status to .true. and check everything
+  call MPI_Status_set_cancelled(f08_status, .true.)
+  call MPI_Status_f082f(f08_status, f_status)
+
+  call check_integer(f_status(MPI_SOURCE), rank, "f082f source 2")
+  call check_integer(f_status(MPI_TAG), expected_tag, "f082f tag 2")
+  call check_integer(f_status(MPI_ERROR), MPI_SUCCESS, "f08f2 error 2")
+  call check_cancelled_f(f_status, .true., "f082f .true.")
+  call check_count_f(f_status, expected_count, "f082f count")
+end subroutine test_fortran_f082f_mpif08
+
+!==================================================================
+
+! This subroutine is called from C.
+! We have to translate the 1/0 from C into a Fortran logical.  Sigh.
+subroutine check_cancelled_f08_wrapper(f08_status, expected_value, msg) &
+     BIND(C, name="check_cancelled_f08_wrapper")
+  use mpi_f08
+  implicit none
+  type(MPI_Status), intent(in) :: f08_status
+  integer, intent(in) :: expected_value
+  character(len=1), intent(in) :: msg
+
+  if (expected_value .eq. 1) then
+     call check_cancelled_f08(f08_status, .true., msg)
+  else
+     call check_cancelled_f08(f08_status, .false., msg)
+   end if
+end subroutine check_cancelled_f08_wrapper
+
+subroutine check_cancelled_f08(f08_status, expected_value, msg)
+  use mpi_f08
+  implicit none
+  type(MPI_Status), intent(in) :: f08_status
+  logical, intent(in) :: expected_value
+  character(len=1), intent(in) :: msg
+  integer :: ierr
+  logical :: value
+
+  call MPI_Test_cancelled(f08_status, value, ierr)
+  if (value .neqv. expected_value) then
+     print *, "Error: ", msg, ": ", value, "<>", expected_value
+     stop
+  end if
+end subroutine check_cancelled_f08
+
+!------------------------------------------------------------------
+
+! This subroutine is called from both Fortran and C
+subroutine check_count_f08(f08_status, expected_count, msg) &
+     BIND(C, name="check_count_f08")
+  use mpi_f08
+  implicit none
+  type(MPI_Status), intent(in) :: f08_status
+  integer, intent(in) :: expected_count
+  character(len=1), intent(in) :: msg
+  integer :: ierr
+  integer :: count
+
+  call MPI_Get_count(f08_status, MPI_INTEGER, count, ierr)
+  call check_integer(count, expected_count, msg)
+end subroutine check_count_f08
+
+!------------------------------------------------------------------
+
+subroutine test_fortran_f2f08_mpi(f_status, expected_tag, expected_count)
+  use mpi
+  implicit none
+  integer, dimension(MPI_STATUS_SIZE), intent(inout) :: f_status
+  integer, intent(in) :: expected_tag
+  integer, intent(in) :: expected_count
+
+  type(MPI_Status) :: f08_status
+  integer :: rank, ierr
+
+  print *, 'Testing Fortran MPI_Status_f2f08 (mpi module)'
+
+  call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+
+  ! Set the canceled status to .false. and check everything
+  call MPI_Status_set_cancelled(f_status, .false., ierr)
+  call MPI_Status_f2f08(f_status, f08_status, ierr)
+
+  call check_integer(f08_status%MPI_SOURCE, rank, "f2f08 source")
+  call check_integer(f08_status%MPI_TAG, expected_tag, "f2f08 tag")
+  call check_integer(f08_status%MPI_ERROR, MPI_SUCCESS, "f2f08 error")
+  call check_cancelled_f08(f08_status, .false., "f2f08 .false.")
+  call check_count_f08(f08_status, expected_count, "f2f08 count")
+
+  ! Set the canceled status to .true. and check everything
+  call MPI_Status_set_cancelled(f_status, .true., ierr)
+  call MPI_Status_f2f08(f_status, f08_status, ierr)
+
+  call check_integer(f08_status%MPI_SOURCE, rank, "f2f08 source 2")
+  call check_integer(f08_status%MPI_TAG, expected_tag, "f2f08 tag 2")
+  call check_integer(f08_status%MPI_ERROR, MPI_SUCCESS, "f08f2 error 2")
+  call check_cancelled_f08(f08_status, .true., "f2f08 .true.")
+  call check_count_f08(f08_status, expected_count, "f2f08 count")
+end subroutine test_fortran_f2f08_mpi
+
+!------------------------------------------------------------------
+
+subroutine test_fortran_f2f08_mpif08(f_status, expected_tag, expected_count)
+  use mpi_f08
+  implicit none
+  integer, dimension(MPI_STATUS_SIZE), intent(inout) :: f_status
+  integer, intent(in) :: expected_tag
+  integer, intent(in) :: expected_count
+
+  type(MPI_Status) :: f08_status
+  integer :: rank
+
+  print *, 'Testing Fortran MPI_Status_f2f08 (mpi_f08 module)'
+
+  call MPI_Comm_rank(MPI_COMM_WORLD, rank)
+
+  ! Coming in to this routine, the f08 status will be set to .true.
+  call MPI_Status_f2f08(f_status, f08_status)
+
+  call check_integer(f08_status%MPI_SOURCE, rank, "f2f08 source 2")
+  call check_integer(f08_status%MPI_TAG, expected_tag, "f2f08 tag 2")
+  call check_integer(f08_status%MPI_ERROR, MPI_SUCCESS, "f08f2 error 2")
+  call check_cancelled_f08(f08_status, .true., "f2f08 .true.")
+  call check_count_f08(f08_status, expected_count, "f2f08 count")
+end subroutine test_fortran_f2f08_mpif08


### PR DESCRIPTION
Test all permutations of MPI_Status conversion functions.  See
MPI-4:18.2.5 for a handy diagram that explains all the MPI_Status
conversion functions and what they need to do.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>