### PR TITLE
sessions: improve error message reporting

### DIFF
--- a/sessions/sessions_test1.c
+++ b/sessions/sessions_test1.c
@@ -3,6 +3,15 @@
 #include <string.h>
 #include "mpi.h"
 
+void print_error(const char *msg, int rc)
+{
+    char err_str[MPI_MAX_ERROR_STRING];
+    int resultlen = sizeof(err_str) - 1;
+
+    MPI_Error_string(rc, err_str,  &resultlen);
+    fprintf (stderr, "%s return err code  = %d (%s)\n", msg, rc, err_str);
+}
+    
 void my_session_errhandler (MPI_Session *foo, int *bar, ...)
 {
     fprintf(stderr, "errhandler called with error %d\n", *bar);
@@ -19,29 +28,34 @@ int main (int argc, char *argv[])
 
     rc = MPI_Session_create_errhandler (my_session_errhandler, &errhandler);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Error handler creation failed with rc = %d\n", rc);
-        abort ();
+        print_error("Error handler creation failed", rc);
+        return -1;
     }
 
     rc = MPI_Info_create (&info);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Info creation failed with rc = %d\n", rc);
-        abort ();
+        print_error("Info creation failed", rc);
+        return -1;
     }
 
     rc = MPI_Info_set(info, "mpi_thread_support_level", "MPI_THREAD_MULTIPLE");
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Info key/val set failed with rc = %d\n", rc);
-        abort ();
+        print_error("Info key/val set failed", rc);
+        return -1;
     }
 
     rc = MPI_Session_init (info, errhandler, &session);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Session initialization failed with rc = %d\n", rc);
-        abort ();
+        print_error("Session initialization failed", rc);
+        return -1;
     }
 
     rc = MPI_Session_get_num_psets (session, MPI_INFO_NULL, &npsets);
+    if (MPI_SUCCESS != rc) {
+        print_error("Session get num psets failed", rc);
+        return -1;
+    }
+
     for (i = 0 ; i < npsets ; ++i) {
         int psetlen = 0;
         char name[256];
@@ -52,11 +66,15 @@ int main (int argc, char *argv[])
 
     rc = MPI_Group_from_session_pset (session, "mpi://WORLD", &group);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Could not get a group for mpi://WORLD. rc = %d\n", rc);
-        abort ();
+        print_error("Could not get a group for mpi://WORLD", rc);
+        return -1;
     }
 
-    MPI_Comm_create_from_group (group, "my_world", MPI_INFO_NULL, MPI_ERRORS_RETURN, &comm_world);
+    rc = MPI_Comm_create_from_group (group, "my_world", MPI_INFO_NULL, MPI_ERRORS_RETURN, &comm_world);
+    if (MPI_SUCCESS != rc) {
+        print_error("Could not get a comm from group", rc);
+        return -1;
+    }
     MPI_Group_free (&group);
 
     MPI_Allreduce (&one, &sum, 1, MPI_INT, MPI_SUM, comm_world);
@@ -65,11 +83,16 @@ int main (int argc, char *argv[])
 
     rc = MPI_Group_from_session_pset (session, "mpi://SELF", &group);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Could not get a group for mpi://SELF. rc = %d\n", rc);
-        abort ();
+        print_error("Could not get a group for mpi://SELF", rc);
+        return -1;
     }
 
     MPI_Comm_create_from_group (group, "myself", MPI_INFO_NULL, MPI_ERRORS_RETURN, &comm_self);
+    if (MPI_SUCCESS != rc) {
+        print_error("Could not get a comm from group", rc);
+        return -1;
+    }
+
     MPI_Group_free (&group);
     MPI_Allreduce (&one, &sum, 1, MPI_INT, MPI_SUM, comm_self);
 
@@ -81,33 +104,38 @@ int main (int argc, char *argv[])
 
     MPI_Comm_free (&comm_world);
     MPI_Comm_free (&comm_self);
-    MPI_Session_finalize (&session);
-    printf("Finished first finalize\n");
+    rc = MPI_Session_finalize (&session);
+    if (MPI_SUCCESS != rc) {
+        print_error("Session finalize returned error", rc);
+        return -1;
+    }
+
+    fprintf(stderr, "Finished first finalize\n");
 
     rc = MPI_Session_create_errhandler (my_session_errhandler, &errhandler);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Error handler creation failed with rc = %d\n", rc);
-        abort ();
+        print_error("Error handler creation failed", rc);
+        return -1;
     }
 
     rc = MPI_Info_create (&info);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Info creation failed with rc = %d\n", rc);
-        abort ();
+        print_error("Info creation failed", rc);
+        return -1;
     }
 
     rc = MPI_Info_set(info, "mpi_thread_support_level", "MPI_THREAD_MULTIPLE");
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Info key/val set failed with rc = %d\n", rc);
-        abort ();
+        print_error("Info key/val set failed", rc);
+        return -1;
     }
 
     printf("Starting second init\n");
     rc = MPI_Session_init (info, errhandler, &session);
     printf("Finished second init\n");
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Session initialization failed with rc = %d\n", rc);
-        abort ();
+        print_error("Session initialization failed", rc);
+        return -1;
     }
 
     rc = MPI_Session_get_num_psets (session, MPI_INFO_NULL, &npsets);
@@ -121,8 +149,8 @@ int main (int argc, char *argv[])
 
     rc = MPI_Group_from_session_pset (session, "mpi://WORLD", &group);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Could not get a group for mpi://WORLD. rc = %d\n", rc);
-        abort ();
+        print_error("Could not get a group for mpi://WORLD", rc);
+        return -1;
     }
 
     MPI_Comm_create_from_group (group, "my_world", MPI_INFO_NULL, MPI_ERRORS_RETURN, &comm_world);
@@ -135,8 +163,8 @@ int main (int argc, char *argv[])
 
     rc = MPI_Group_from_session_pset (session, "mpi://SELF", &group);
     if (MPI_SUCCESS != rc) {
-        fprintf (stderr, "Could not get a group for mpi://SELF. rc = %d\n", rc);
-        abort ();
+        print_error("Could not get a group for mpi://SELF ", rc);
+        return -1;
     }
 
     MPI_Comm_create_from_group (group, "myself", MPI_INFO_NULL, MPI_ERRORS_RETURN, &comm_self);


### PR DESCRIPTION
add error string in addition to error code in output
when a method fails.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>