### PR TITLE
adding more symbols to the allowed-list in nmcheck

### DIFF
--- a/packaging/nmcheck_prefix.pl
+++ b/packaging/nmcheck_prefix.pl
@@ -124,6 +124,18 @@ sub check_lib_for_bad_exports {
     @symbols = grep(!/^tm_/, @symbols);  # tempted to require ompi_ here
     @symbols = grep(!/^mca_/, @symbols);
     @symbols = grep(!/^smpi_/, @symbols);
+    @symbols = grep(!/^MPL_/, @symbols);
+    @symbols = grep(!/^MPLI_/, @symbols);
+    @symbols = grep(!/^PQ_/, @symbols);
+
+    # libhwloc can have hwloc_ symbols of course, and
+    # libpmix can have pmix_*:
+    if ($lib =~ /libhwloc\./) {
+        @symbols = grep(!/^hwloc_/, @symbols);
+    }
+    if ($lib =~ /libpmix\./) {
+        @symbols = grep(!/^pmix[0-9]*_/, @symbols);
+    }
 
     @symbols = grep(!/^_fini$/, @symbols);
     @symbols = grep(!/^_init$/, @symbols);


### PR DESCRIPTION
I don't want this testcase to be too aggressive about declaring
errors for things that might be okay.

Things allowed by this checkin that definitely should be allowed:
  libhwloc.so can have hwloc_ symbols
  libpmix.so can have pmix_ symbols
I'm also allowing PQ_ which seems unlikely to conflict with
user-apps and comes from treematch.

Signed-off-by: Mark Allen <markalle@us.ibm.com>